### PR TITLE
Phase 2: Add authentication screens (Login & Registration)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.auth.AuthActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Geoeventandroid" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/geoevent/MainActivity.kt
+++ b/app/src/main/java/com/geoevent/MainActivity.kt
@@ -2,8 +2,10 @@ package com.geoevent
 
 import LocationHelper
 import android.Manifest
+import android.content.Intent
 import android.location.Location
 import android.os.Bundle
+import android.view.Menu
 import android.view.MenuItem
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
@@ -12,16 +14,26 @@ import androidx.navigation.findNavController
 import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
+import com.geoevent.data.auth.SessionManager
 import com.geoevent.databinding.ActivityMainBinding
+import com.geoevent.ui.auth.AuthActivity
 import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class MainActivity : AppCompatActivity() {
     private val LOCATION_PERMISSION_REQUEST_CODE = 1001
     private lateinit var binding: ActivityMainBinding
     private var lastLocation: Location? = null
+    private lateinit var sessionManager: SessionManager
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Check if user is logged in
+        sessionManager = SessionManager(this)
+        if (!sessionManager.isLoggedIn()) {
+            navigateToAuth()
+            return
+        }
         val locationHelper: LocationHelper = LocationHelper(applicationContext)
 
         // Request permission
@@ -59,5 +71,32 @@ class MainActivity : AppCompatActivity() {
         val text = findViewById<TextView>(R.id.text_dashboard)
         text.setText("lat: ${lastLocation?.latitude}, long: ${lastLocation?.longitude}, a:${lastLocation?.accuracy}")
         println("Making geostamp from last location, lat: ${lastLocation?.latitude}, long: ${lastLocation?.longitude}, a:${lastLocation?.accuracy}")
+    }
+
+    private fun navigateToAuth() {
+        val intent = Intent(this, AuthActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        finish()
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.main_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.action_logout -> {
+                logout()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun logout() {
+        sessionManager.clearSession()
+        navigateToAuth()
     }
 }

--- a/app/src/main/java/com/geoevent/ui/auth/AuthActivity.kt
+++ b/app/src/main/java/com/geoevent/ui/auth/AuthActivity.kt
@@ -1,0 +1,20 @@
+package com.geoevent.ui.auth
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.geoevent.R
+
+class AuthActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_auth)
+
+        // Show login fragment on first launch
+        if (savedInstanceState == null) {
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.auth_container, LoginFragment())
+                .commit()
+        }
+    }
+}

--- a/app/src/main/java/com/geoevent/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/geoevent/ui/auth/AuthViewModel.kt
@@ -1,0 +1,87 @@
+package com.geoevent.ui.auth
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.geoevent.data.api.RetrofitClient
+import com.geoevent.data.auth.SessionManager
+import com.geoevent.data.model.User
+import com.geoevent.data.repository.AuthRepository
+import kotlinx.coroutines.launch
+
+class AuthViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val sessionManager = SessionManager(application)
+    private val authRepository = AuthRepository(
+        RetrofitClient.getAuthService(sessionManager)
+    )
+
+    private val _loginState = MutableLiveData<AuthState>()
+    val loginState: LiveData<AuthState> = _loginState
+
+    private val _registerState = MutableLiveData<AuthState>()
+    val registerState: LiveData<AuthState> = _registerState
+
+    fun login(phoneNumber: String, password: String) {
+        viewModelScope.launch {
+            try {
+                _loginState.value = AuthState.Loading
+
+                val response = authRepository.login(phoneNumber, password)
+
+                if (response.isSuccessful && response.body() != null) {
+                    val token = response.body()!!.token
+                    sessionManager.saveAuthToken(token)
+                    _loginState.value = AuthState.Success
+                } else {
+                    _loginState.value = AuthState.Error("Login failed: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _loginState.value = AuthState.Error("Login error: ${e.message}")
+            }
+        }
+    }
+
+    fun register(userId: String, phoneNumber: String, name: String, password: String) {
+        viewModelScope.launch {
+            try {
+                _registerState.value = AuthState.Loading
+
+                // Create user
+                val user = User(id = userId, phoneNumber = phoneNumber, name = name)
+                val registerResponse = authRepository.register(user)
+
+                if (registerResponse.isSuccessful) {
+                    // Auto-login after registration
+                    val loginResponse = authRepository.login(phoneNumber, password)
+
+                    if (loginResponse.isSuccessful && loginResponse.body() != null) {
+                        val token = loginResponse.body()!!.token
+                        sessionManager.saveAuthToken(token)
+                        sessionManager.saveUserInfo(userId, name, phoneNumber)
+                        _registerState.value = AuthState.Success
+                    } else {
+                        _registerState.value = AuthState.Error("Registration successful but login failed")
+                    }
+                } else {
+                    _registerState.value = AuthState.Error("Registration failed: ${registerResponse.code()}")
+                }
+            } catch (e: Exception) {
+                _registerState.value = AuthState.Error("Registration error: ${e.message}")
+            }
+        }
+    }
+
+    fun isLoggedIn(): Boolean {
+        return sessionManager.isLoggedIn()
+    }
+
+    sealed class AuthState {
+        object Idle : AuthState()
+        object Loading : AuthState()
+        object Success : AuthState()
+        data class Error(val message: String) : AuthState()
+    }
+}

--- a/app/src/main/java/com/geoevent/ui/auth/LoginFragment.kt
+++ b/app/src/main/java/com/geoevent/ui/auth/LoginFragment.kt
@@ -1,0 +1,113 @@
+package com.geoevent.ui.auth
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.geoevent.MainActivity
+import com.geoevent.databinding.FragmentLoginBinding
+
+class LoginFragment : Fragment() {
+
+    private var _binding: FragmentLoginBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var viewModel: AuthViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentLoginBinding.inflate(inflater, container, false)
+        viewModel = ViewModelProvider(this)[AuthViewModel::class.java]
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupObservers()
+        setupClickListeners()
+    }
+
+    private fun setupObservers() {
+        viewModel.loginState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is AuthViewModel.AuthState.Loading -> {
+                    binding.progressBar.visibility = View.VISIBLE
+                    binding.buttonLogin.isEnabled = false
+                    binding.textError.visibility = View.GONE
+                }
+                is AuthViewModel.AuthState.Success -> {
+                    binding.progressBar.visibility = View.GONE
+                    Toast.makeText(requireContext(), "Login successful!", Toast.LENGTH_SHORT).show()
+                    navigateToDashboard()
+                }
+                is AuthViewModel.AuthState.Error -> {
+                    binding.progressBar.visibility = View.GONE
+                    binding.buttonLogin.isEnabled = true
+                    binding.textError.text = state.message
+                    binding.textError.visibility = View.VISIBLE
+                }
+                else -> {
+                    binding.progressBar.visibility = View.GONE
+                    binding.buttonLogin.isEnabled = true
+                }
+            }
+        }
+    }
+
+    private fun setupClickListeners() {
+        binding.buttonLogin.setOnClickListener {
+            val phoneNumber = binding.editPhone.text.toString().trim()
+            val password = binding.editPassword.text.toString().trim()
+
+            if (validateInputs(phoneNumber, password)) {
+                viewModel.login(phoneNumber, password)
+            }
+        }
+
+        binding.textRegister.setOnClickListener {
+            navigateToRegister()
+        }
+    }
+
+    private fun validateInputs(phoneNumber: String, password: String): Boolean {
+        if (phoneNumber.isEmpty()) {
+            binding.tilPhone.error = "Phone number required"
+            return false
+        }
+        binding.tilPhone.error = null
+
+        if (password.isEmpty()) {
+            binding.tilPassword.error = "Password required"
+            return false
+        }
+        binding.tilPassword.error = null
+
+        return true
+    }
+
+    private fun navigateToDashboard() {
+        val intent = Intent(requireContext(), MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        requireActivity().finish()
+    }
+
+    private fun navigateToRegister() {
+        parentFragmentManager.beginTransaction()
+            .replace((view?.parent as ViewGroup).id, RegisterFragment())
+            .addToBackStack(null)
+            .commit()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/geoevent/ui/auth/RegisterFragment.kt
+++ b/app/src/main/java/com/geoevent/ui/auth/RegisterFragment.kt
@@ -1,0 +1,119 @@
+package com.geoevent.ui.auth
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.geoevent.MainActivity
+import com.geoevent.databinding.FragmentRegisterBinding
+import java.util.UUID
+
+class RegisterFragment : Fragment() {
+
+    private var _binding: FragmentRegisterBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var viewModel: AuthViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentRegisterBinding.inflate(inflater, container, false)
+        viewModel = ViewModelProvider(this)[AuthViewModel::class.java]
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupObservers()
+        setupClickListeners()
+    }
+
+    private fun setupObservers() {
+        viewModel.registerState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is AuthViewModel.AuthState.Loading -> {
+                    binding.progressBar.visibility = View.VISIBLE
+                    binding.buttonRegister.isEnabled = false
+                    binding.textError.visibility = View.GONE
+                }
+                is AuthViewModel.AuthState.Success -> {
+                    binding.progressBar.visibility = View.GONE
+                    Toast.makeText(requireContext(), "Registration successful!", Toast.LENGTH_SHORT).show()
+                    navigateToDashboard()
+                }
+                is AuthViewModel.AuthState.Error -> {
+                    binding.progressBar.visibility = View.GONE
+                    binding.buttonRegister.isEnabled = true
+                    binding.textError.text = state.message
+                    binding.textError.visibility = View.VISIBLE
+                }
+                else -> {
+                    binding.progressBar.visibility = View.GONE
+                    binding.buttonRegister.isEnabled = true
+                }
+            }
+        }
+    }
+
+    private fun setupClickListeners() {
+        binding.buttonRegister.setOnClickListener {
+            val name = binding.editName.text.toString().trim()
+            val phoneNumber = binding.editPhone.text.toString().trim()
+            val password = binding.editPassword.text.toString().trim()
+
+            if (validateInputs(name, phoneNumber, password)) {
+                val userId = UUID.randomUUID().toString()
+                viewModel.register(userId, phoneNumber, name, password)
+            }
+        }
+
+        binding.textLogin.setOnClickListener {
+            parentFragmentManager.popBackStack()
+        }
+    }
+
+    private fun validateInputs(name: String, phoneNumber: String, password: String): Boolean {
+        if (name.isEmpty()) {
+            binding.tilName.error = "Name required"
+            return false
+        }
+        binding.tilName.error = null
+
+        if (phoneNumber.isEmpty()) {
+            binding.tilPhone.error = "Phone number required"
+            return false
+        }
+        binding.tilPhone.error = null
+
+        if (password.isEmpty()) {
+            binding.tilPassword.error = "Password required"
+            return false
+        }
+        if (password.length < 6) {
+            binding.tilPassword.error = "Password must be at least 6 characters"
+            return false
+        }
+        binding.tilPassword.error = null
+
+        return true
+    }
+
+    private fun navigateToDashboard() {
+        val intent = Intent(requireContext(), MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        startActivity(intent)
+        requireActivity().finish()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/res/layout/activity_auth.xml
+++ b/app/src/main/res/layout/activity_auth.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/auth_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/app/src/main/res/layout/fragment_login.xml
+++ b/app/src/main/res/layout/fragment_login.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="GeoEvent Login"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="80dp" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_phone"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Phone Number"
+        app:layout_constraintTop_toBottomOf="@id/text_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="40dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_phone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="phone" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_password"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Password"
+        app:passwordToggleEnabled="true"
+        app:layout_constraintTop_toBottomOf="@id/til_phone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_login"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Login"
+        android:textSize="16sp"
+        app:layout_constraintTop_toBottomOf="@id/til_password"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="24dp" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/button_login"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp" />
+
+    <TextView
+        android:id="@+id/text_error"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/holo_red_dark"
+        android:textSize="14sp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/progress_bar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp" />
+
+    <TextView
+        android:id="@+id/text_register"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Don't have an account? Register"
+        android:textSize="14sp"
+        android:textColor="?attr/colorPrimary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="40dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_register.xml
+++ b/app/src/main/res/layout/fragment_register.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Create Account"
+        android:textSize="28sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="60dp" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_name"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Full Name"
+        app:layout_constraintTop_toBottomOf="@id/text_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="40dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPersonName" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_phone"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Phone Number"
+        app:layout_constraintTop_toBottomOf="@id/til_name"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_phone"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="phone" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/til_password"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Password"
+        app:passwordToggleEnabled="true"
+        app:layout_constraintTop_toBottomOf="@id/til_phone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/edit_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="textPassword" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/button_register"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Register"
+        android:textSize="16sp"
+        app:layout_constraintTop_toBottomOf="@id/til_password"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="24dp" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/button_register"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp" />
+
+    <TextView
+        android:id="@+id/text_error"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textColor="@android:color/holo_red_dark"
+        android:textSize="14sp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/progress_bar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp" />
+
+    <TextView
+        android:id="@+id/text_login"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Already have an account? Login"
+        android:textSize="14sp"
+        android:textColor="?attr/colorPrimary"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="40dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_logout"
+        android:title="Logout"
+        app:showAsAction="never" />
+</menu>


### PR DESCRIPTION
This commit implements user authentication UI:
- Created AuthViewModel for handling login/registration logic
- Implemented LoginFragment with phone number and password inputs
- Implemented RegisterFragment with name, phone, and password inputs
- Created AuthActivity to host auth fragments
- Updated MainActivity to check login state on launch
- Added logout functionality with menu option
- Integrated SessionManager for auth state management
- Auto-login after successful registration
- Form validation and error handling
- Loading states with progress indicators
- Navigation between login/register screens

User Flow:
1. App launches → MainActivity checks login state
2. If not logged in → Navigate to AuthActivity (Login screen)
3. User can register → Auto-login → Navigate to Dashboard
4. User can login → Navigate to Dashboard
5. User can logout from menu → Back to Login

Generated with [Claude Code](https://claude.com/claude-code)