### PR TITLE
Phase 4: GeoStamps Fragment with CRUD operations

### DIFF
--- a/app/src/main/java/com/geoevent/ui/geostamps/GeoStampsAdapter.kt
+++ b/app/src/main/java/com/geoevent/ui/geostamps/GeoStampsAdapter.kt
@@ -1,0 +1,71 @@
+package com.geoevent.ui.geostamps
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.geoevent.data.model.GeoStamp
+import com.geoevent.databinding.ItemGeostampActionsBinding
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class GeoStampsAdapter(
+    private val onDeleteClick: (GeoStamp) -> Unit
+) : ListAdapter<GeoStamp, GeoStampsAdapter.GeoStampViewHolder>(DiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GeoStampViewHolder {
+        val binding = ItemGeostampActionsBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return GeoStampViewHolder(binding, onDeleteClick)
+    }
+
+    override fun onBindViewHolder(holder: GeoStampViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class GeoStampViewHolder(
+        private val binding: ItemGeostampActionsBinding,
+        private val onDeleteClick: (GeoStamp) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(geoStamp: GeoStamp) {
+            binding.textStampId.text = "ID: ${geoStamp.id.take(8)}..."
+
+            val locationText = if (geoStamp.latitude != null && geoStamp.longitude != null) {
+                "Location: ${String.format("%.4f", geoStamp.latitude)}, ${String.format("%.4f", geoStamp.longitude)}"
+            } else {
+                "Location: Not available"
+            }
+            binding.textLocation.text = locationText
+
+            val dateFormat = SimpleDateFormat("MMM dd, yyyy HH:mm", Locale.getDefault())
+            val date = Date(geoStamp.timestamp)
+            binding.textTimestamp.text = "Created: ${dateFormat.format(date)}"
+
+            binding.textEventStatus.text = if (geoStamp.geoEventId != null) {
+                "Linked to event: ${geoStamp.geoEventId.take(8)}..."
+            } else {
+                "No event linked"
+            }
+
+            binding.buttonDelete.setOnClickListener {
+                onDeleteClick(geoStamp)
+            }
+        }
+    }
+
+    private class DiffCallback : DiffUtil.ItemCallback<GeoStamp>() {
+        override fun areItemsTheSame(oldItem: GeoStamp, newItem: GeoStamp): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: GeoStamp, newItem: GeoStamp): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/geoevent/ui/geostamps/GeoStampsFragment.kt
+++ b/app/src/main/java/com/geoevent/ui/geostamps/GeoStampsFragment.kt
@@ -1,38 +1,93 @@
 package com.geoevent.ui.geostamps
 
+import android.app.AlertDialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import com.geoevent.databinding.FragmentHomeBinding
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.geoevent.databinding.FragmentGeostampsBinding
 
 class GeoStampsFragment : Fragment() {
 
-    private var _binding: FragmentHomeBinding? = null
-
-    // This property is only valid between onCreateView and
-    // onDestroyView.
+    private var _binding: FragmentGeostampsBinding? = null
     private val binding get() = _binding!!
+
+    private lateinit var viewModel: GeoStampsViewModel
+    private lateinit var adapter: GeoStampsAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val homeViewModel =
-            ViewModelProvider(this).get(GeoStampsViewModel::class.java)
+        _binding = FragmentGeostampsBinding.inflate(inflater, container, false)
+        viewModel = ViewModelProvider(this)[GeoStampsViewModel::class.java]
 
-        _binding = FragmentHomeBinding.inflate(inflater, container, false)
-        val root: View = binding.root
+        setupRecyclerView()
+        setupObservers()
 
-        val textView: TextView = binding.textHome
-        homeViewModel.text.observe(viewLifecycleOwner) {
-            textView.text = it
+        return binding.root
+    }
+
+    private fun setupRecyclerView() {
+        adapter = GeoStampsAdapter(
+            onDeleteClick = { geoStamp ->
+                showDeleteConfirmation(geoStamp.id)
+            }
+        )
+        binding.recyclerStamps.layoutManager = LinearLayoutManager(requireContext())
+        binding.recyclerStamps.adapter = adapter
+    }
+
+    private fun setupObservers() {
+        // Observe geostamps list
+        viewModel.geoStamps.observe(viewLifecycleOwner) { stamps ->
+            adapter.submitList(stamps)
+
+            // Show empty state if no stamps
+            if (stamps.isEmpty()) {
+                binding.recyclerStamps.visibility = View.GONE
+                binding.textEmpty.visibility = View.VISIBLE
+            } else {
+                binding.recyclerStamps.visibility = View.VISIBLE
+                binding.textEmpty.visibility = View.GONE
+            }
         }
-        return root
+
+        // Observe operation state
+        viewModel.operationState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is GeoStampsViewModel.OperationState.Loading -> {
+                    binding.progressBar.visibility = View.VISIBLE
+                }
+                is GeoStampsViewModel.OperationState.Success -> {
+                    binding.progressBar.visibility = View.GONE
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                }
+                is GeoStampsViewModel.OperationState.Error -> {
+                    binding.progressBar.visibility = View.GONE
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                }
+                else -> {
+                    binding.progressBar.visibility = View.GONE
+                }
+            }
+        }
+    }
+
+    private fun showDeleteConfirmation(stampId: String) {
+        AlertDialog.Builder(requireContext())
+            .setTitle("Delete GeoStamp")
+            .setMessage("Are you sure you want to delete this geostamp?")
+            .setPositiveButton("Delete") { _, _ ->
+                viewModel.deleteGeoStamp(stampId)
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/geoevent/ui/geostamps/GeoStampsViewModel.kt
+++ b/app/src/main/java/com/geoevent/ui/geostamps/GeoStampsViewModel.kt
@@ -1,13 +1,103 @@
 package com.geoevent.ui.geostamps
 
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.geoevent.data.api.RetrofitClient
+import com.geoevent.data.auth.SessionManager
+import com.geoevent.data.model.GeoStamp
+import com.geoevent.data.repository.GeoStampRepository
+import kotlinx.coroutines.launch
 
-class GeoStampsViewModel : ViewModel() {
+class GeoStampsViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "[GEO STAMPS]"
+    private val sessionManager = SessionManager(application)
+    private val geoStampRepository = GeoStampRepository(
+        RetrofitClient.getGeoStampService(sessionManager)
+    )
+
+    private val _geoStamps = MutableLiveData<List<GeoStamp>>()
+    val geoStamps: LiveData<List<GeoStamp>> = _geoStamps
+
+    private val _operationState = MutableLiveData<OperationState>()
+    val operationState: LiveData<OperationState> = _operationState
+
+    init {
+        loadGeoStamps()
     }
-    val text: LiveData<String> = _text
+
+    fun loadGeoStamps() {
+        viewModelScope.launch {
+            try {
+                _operationState.value = OperationState.Loading
+
+                val response = geoStampRepository.getGeoStamps()
+
+                if (response.isSuccessful && response.body() != null) {
+                    _geoStamps.value = response.body()!!
+                    _operationState.value = OperationState.Success("Loaded ${response.body()!!.size} geostamps")
+                } else {
+                    _operationState.value = OperationState.Error("Failed to load geostamps: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _operationState.value = OperationState.Error("Error: ${e.message}")
+            }
+        }
+    }
+
+    fun deleteGeoStamp(stampId: String) {
+        viewModelScope.launch {
+            try {
+                _operationState.value = OperationState.Loading
+
+                val response = geoStampRepository.deleteGeoStamp(stampId)
+
+                if (response.isSuccessful) {
+                    _operationState.value = OperationState.Success("GeoStamp deleted")
+                    loadGeoStamps() // Reload list
+                } else {
+                    _operationState.value = OperationState.Error("Failed to delete: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _operationState.value = OperationState.Error("Error: ${e.message}")
+            }
+        }
+    }
+
+    fun linkToEvent(stampId: String, eventId: String) {
+        viewModelScope.launch {
+            try {
+                _operationState.value = OperationState.Loading
+
+                // Get the current stamp
+                val currentStamp = _geoStamps.value?.find { it.id == stampId }
+                if (currentStamp == null) {
+                    _operationState.value = OperationState.Error("Stamp not found")
+                    return@launch
+                }
+
+                // Update with event ID
+                val updatedStamp = currentStamp.copy(geoEventId = eventId)
+                val response = geoStampRepository.updateGeoStamp(stampId, updatedStamp)
+
+                if (response.isSuccessful) {
+                    _operationState.value = OperationState.Success("Linked to event")
+                    loadGeoStamps() // Reload list
+                } else {
+                    _operationState.value = OperationState.Error("Failed to link: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _operationState.value = OperationState.Error("Error: ${e.message}")
+            }
+        }
+    }
+
+    sealed class OperationState {
+        object Idle : OperationState()
+        object Loading : OperationState()
+        data class Success(val message: String) : OperationState()
+        data class Error(val message: String) : OperationState()
+    }
 }

--- a/app/src/main/res/layout/fragment_geostamps.xml
+++ b/app/src/main/res/layout/fragment_geostamps.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".ui.geostamps.GeoStampsFragment">
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="GeoStamps"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="8dp" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/text_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp" />
+
+    <TextView
+        android:id="@+id/text_empty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No GeoStamps yet.\nGo to Dashboard to create one!"
+        android:textSize="16sp"
+        android:textAlignment="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_stamps"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/text_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp"
+        tools:listitem="@layout/item_geostamp_actions" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_geostamp_actions.xml
+++ b/app/src/main/res/layout/item_geostamp_actions.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardElevation="2dp"
+    app:cardCornerRadius="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="12dp">
+
+        <TextView
+            android:id="@+id/text_stamp_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="GeoStamp ID"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/text_location"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Location: 0.0, 0.0"
+            android:textSize="12sp"
+            android:layout_marginTop="4dp" />
+
+        <TextView
+            android:id="@+id/text_timestamp"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Created: "
+            android:textSize="12sp"
+            android:textColor="@android:color/darker_gray"
+            android:layout_marginTop="4dp" />
+
+        <TextView
+            android:id="@+id/text_event_status"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="No event linked"
+            android:textSize="12sp"
+            android:textColor="?attr/colorPrimary"
+            android:layout_marginTop="4dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_delete"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Delete"
+                android:textColor="@android:color/holo_red_dark" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
This commit implements the GeoStamps tab with full management:
- Updated GeoStampsViewModel with CRUD operations
- Implemented loadGeoStamps() to fetch all user's stamps
- Implemented deleteGeoStamp() with API integration
- Implemented linkToEvent() for future event linking
- Created new fragment_geostamps.xml layout
- Created GeoStampsAdapter with delete action button
- Created item_geostamp_actions.xml with delete button
- Updated GeoStampsFragment with full functionality
- Added empty state when no geostamps exist
- Added delete confirmation dialog
- Loading states and error handling
- Auto-refresh after delete operation
- Toast notifications for user feedback

Features:
- View all geostamps in a list
- Delete geostamps with confirmation dialog
- Empty state with helpful message
- Real-time list updates after operations
- Proper error handling
- Material Design UI

User Flow:
1. View all geostamps in the GeoStamps tab
2. Click "Delete" on any geostamp
3. Confirm deletion in dialog
4. Geostamp deleted from server
5. List auto-refreshes

Generated with [Claude Code](https://claude.com/claude-code)