### PR TITLE
Phase 5: GeoEvents Fragment with create, list, and delete

### DIFF
--- a/app/src/main/java/com/geoevent/ui/geoevents/GeoEventsAdapter.kt
+++ b/app/src/main/java/com/geoevent/ui/geoevents/GeoEventsAdapter.kt
@@ -1,0 +1,58 @@
+package com.geoevent.ui.geoevents
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.geoevent.data.model.GeoEvent
+import com.geoevent.databinding.ItemGeoeventBinding
+
+class GeoEventsAdapter(
+    private val onViewChatClick: (GeoEvent) -> Unit,
+    private val onDeleteClick: (GeoEvent) -> Unit
+) : ListAdapter<GeoEvent, GeoEventsAdapter.GeoEventViewHolder>(DiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GeoEventViewHolder {
+        val binding = ItemGeoeventBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return GeoEventViewHolder(binding, onViewChatClick, onDeleteClick)
+    }
+
+    override fun onBindViewHolder(holder: GeoEventViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class GeoEventViewHolder(
+        private val binding: ItemGeoeventBinding,
+        private val onViewChatClick: (GeoEvent) -> Unit,
+        private val onDeleteClick: (GeoEvent) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(geoEvent: GeoEvent) {
+            binding.textEventId.text = "Event: ${geoEvent.id.take(8)}..."
+            binding.textUserId.text = "Created by: ${geoEvent.userId.take(8)}..."
+
+            binding.buttonViewChat.setOnClickListener {
+                onViewChatClick(geoEvent)
+            }
+
+            binding.buttonDelete.setOnClickListener {
+                onDeleteClick(geoEvent)
+            }
+        }
+    }
+
+    private class DiffCallback : DiffUtil.ItemCallback<GeoEvent>() {
+        override fun areItemsTheSame(oldItem: GeoEvent, newItem: GeoEvent): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: GeoEvent, newItem: GeoEvent): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/geoevent/ui/geoevents/GeoEventsFragment.kt
+++ b/app/src/main/java/com/geoevent/ui/geoevents/GeoEventsFragment.kt
@@ -1,38 +1,135 @@
 package com.geoevent.ui.geoevents
 
+import android.app.AlertDialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
+import android.widget.ArrayAdapter
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import com.geoevent.databinding.FragmentNotificationsBinding
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.geoevent.R
+import com.geoevent.databinding.FragmentGeoeventsBinding
 
 class GeoEventsFragment : Fragment() {
 
-    private var _binding: FragmentNotificationsBinding? = null
-
-    // This property is only valid between onCreateView and
-    // onDestroyView.
+    private var _binding: FragmentGeoeventsBinding? = null
     private val binding get() = _binding!!
+
+    private lateinit var viewModel: GeoEventsViewModel
+    private lateinit var adapter: GeoEventsAdapter
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val notificationsViewModel =
-            ViewModelProvider(this).get(GeoEventsViewModel::class.java)
+        _binding = FragmentGeoeventsBinding.inflate(inflater, container, false)
+        viewModel = ViewModelProvider(this)[GeoEventsViewModel::class.java]
 
-        _binding = FragmentNotificationsBinding.inflate(inflater, container, false)
-        val root: View = binding.root
+        setupRecyclerView()
+        setupObservers()
+        setupClickListeners()
 
-        val textView: TextView = binding.textNotifications
-        notificationsViewModel.text.observe(viewLifecycleOwner) {
-            textView.text = it
+        return binding.root
+    }
+
+    private fun setupRecyclerView() {
+        adapter = GeoEventsAdapter(
+            onViewChatClick = { geoEvent ->
+                // Navigate to messages tab - will be implemented in Phase 6
+                Toast.makeText(requireContext(), "Chat for event ${geoEvent.id.take(8)}... (Coming in Phase 6)", Toast.LENGTH_SHORT).show()
+                // Navigate to Messages tab
+                findNavController().navigate(R.id.navigation_message)
+            },
+            onDeleteClick = { geoEvent ->
+                showDeleteConfirmation(geoEvent.id)
+            }
+        )
+        binding.recyclerEvents.layoutManager = LinearLayoutManager(requireContext())
+        binding.recyclerEvents.adapter = adapter
+    }
+
+    private fun setupObservers() {
+        // Observe events list
+        viewModel.geoEvents.observe(viewLifecycleOwner) { events ->
+            adapter.submitList(events)
+
+            // Show empty state if no events
+            if (events.isEmpty()) {
+                binding.recyclerEvents.visibility = View.GONE
+                binding.textEmpty.visibility = View.VISIBLE
+            } else {
+                binding.recyclerEvents.visibility = View.VISIBLE
+                binding.textEmpty.visibility = View.GONE
+            }
         }
-        return root
+
+        // Observe operation state
+        viewModel.operationState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is GeoEventsViewModel.OperationState.Loading -> {
+                    binding.progressBar.visibility = View.VISIBLE
+                }
+                is GeoEventsViewModel.OperationState.Success -> {
+                    binding.progressBar.visibility = View.GONE
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                }
+                is GeoEventsViewModel.OperationState.Error -> {
+                    binding.progressBar.visibility = View.GONE
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                }
+                else -> {
+                    binding.progressBar.visibility = View.GONE
+                }
+            }
+        }
+    }
+
+    private fun setupClickListeners() {
+        binding.fabCreateEvent.setOnClickListener {
+            showCreateEventDialog()
+        }
+    }
+
+    private fun showCreateEventDialog() {
+        val stamps = viewModel.availableStamps.value
+
+        if (stamps.isNullOrEmpty()) {
+            Toast.makeText(
+                requireContext(),
+                "No available GeoStamps. Create one in Dashboard first!",
+                Toast.LENGTH_LONG
+            ).show()
+            return
+        }
+
+        val stampNames = stamps.map { "Stamp: ${it.id.take(8)}... (Lat: ${String.format("%.4f", it.latitude ?: 0.0)}, Lon: ${String.format("%.4f", it.longitude ?: 0.0)})" }
+        val adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, stampNames)
+
+        AlertDialog.Builder(requireContext())
+            .setTitle("Create GeoEvent")
+            .setMessage("Select a GeoStamp to link to this event:")
+            .setAdapter(adapter) { _, which ->
+                val selectedStamp = stamps[which]
+                viewModel.createGeoEvent(selectedStamp.id)
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
+    private fun showDeleteConfirmation(eventId: String) {
+        AlertDialog.Builder(requireContext())
+            .setTitle("Delete GeoEvent")
+            .setMessage("Are you sure you want to delete this event?")
+            .setPositiveButton("Delete") { _, _ ->
+                viewModel.deleteGeoEvent(eventId)
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/geoevent/ui/geoevents/GeoEventsViewModel.kt
+++ b/app/src/main/java/com/geoevent/ui/geoevents/GeoEventsViewModel.kt
@@ -1,13 +1,138 @@
 package com.geoevent.ui.geoevents
 
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.geoevent.data.api.RetrofitClient
+import com.geoevent.data.auth.SessionManager
+import com.geoevent.data.model.GeoEvent
+import com.geoevent.data.model.GeoStamp
+import com.geoevent.data.repository.GeoEventRepository
+import com.geoevent.data.repository.GeoStampRepository
+import kotlinx.coroutines.launch
+import java.util.UUID
 
-class GeoEventsViewModel : ViewModel() {
+class GeoEventsViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "[GEO EVENTS]"
+    private val sessionManager = SessionManager(application)
+    private val geoEventRepository = GeoEventRepository(
+        RetrofitClient.getGeoEventService(sessionManager)
+    )
+    private val geoStampRepository = GeoStampRepository(
+        RetrofitClient.getGeoStampService(sessionManager)
+    )
+
+    private val _geoEvents = MutableLiveData<List<GeoEvent>>()
+    val geoEvents: LiveData<List<GeoEvent>> = _geoEvents
+
+    private val _availableStamps = MutableLiveData<List<GeoStamp>>()
+    val availableStamps: LiveData<List<GeoStamp>> = _availableStamps
+
+    private val _operationState = MutableLiveData<OperationState>()
+    val operationState: LiveData<OperationState> = _operationState
+
+    init {
+        loadGeoEvents()
+        loadAvailableStamps()
     }
-    val text: LiveData<String> = _text
+
+    fun loadGeoEvents() {
+        viewModelScope.launch {
+            try {
+                _operationState.value = OperationState.Loading
+
+                val response = geoEventRepository.getGeoEvents()
+
+                if (response.isSuccessful && response.body() != null) {
+                    _geoEvents.value = response.body()!!
+                    _operationState.value = OperationState.Success("Loaded ${response.body()!!.size} events")
+                } else {
+                    _operationState.value = OperationState.Error("Failed to load events: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _operationState.value = OperationState.Error("Error: ${e.message}")
+            }
+        }
+    }
+
+    fun loadAvailableStamps() {
+        viewModelScope.launch {
+            try {
+                val response = geoStampRepository.getGeoStamps()
+                if (response.isSuccessful && response.body() != null) {
+                    // Filter stamps that don't have an event linked
+                    val unlinkedStamps = response.body()!!.filter { it.geoEventId == null }
+                    _availableStamps.value = unlinkedStamps
+                }
+            } catch (e: Exception) {
+                // Silently fail for available stamps load
+            }
+        }
+    }
+
+    fun createGeoEvent(stampId: String) {
+        val userId = sessionManager.getUserId()
+        if (userId == null) {
+            _operationState.value = OperationState.Error("User not logged in")
+            return
+        }
+
+        viewModelScope.launch {
+            try {
+                _operationState.value = OperationState.Loading
+
+                val eventId = UUID.randomUUID().toString()
+                val geoEvent = GeoEvent(id = eventId, userId = userId)
+
+                // Create the event
+                val createResponse = geoEventRepository.createGeoEvent(geoEvent)
+
+                if (createResponse.isSuccessful) {
+                    // Link the stamp to this event
+                    val stamp = _availableStamps.value?.find { it.id == stampId }
+                    if (stamp != null) {
+                        val updatedStamp = stamp.copy(geoEventId = eventId)
+                        geoStampRepository.updateGeoStamp(stampId, updatedStamp)
+                    }
+
+                    _operationState.value = OperationState.Success("GeoEvent created")
+                    loadGeoEvents()
+                    loadAvailableStamps()
+                } else {
+                    _operationState.value = OperationState.Error("Failed to create event: ${createResponse.code()}")
+                }
+            } catch (e: Exception) {
+                _operationState.value = OperationState.Error("Error: ${e.message}")
+            }
+        }
+    }
+
+    fun deleteGeoEvent(eventId: String) {
+        viewModelScope.launch {
+            try {
+                _operationState.value = OperationState.Loading
+
+                val response = geoEventRepository.deleteGeoEvent(eventId)
+
+                if (response.isSuccessful) {
+                    _operationState.value = OperationState.Success("GeoEvent deleted")
+                    loadGeoEvents()
+                    loadAvailableStamps()
+                } else {
+                    _operationState.value = OperationState.Error("Failed to delete: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _operationState.value = OperationState.Error("Error: ${e.message}")
+            }
+        }
+    }
+
+    sealed class OperationState {
+        object Idle : OperationState()
+        object Loading : OperationState()
+        data class Success(val message: String) : OperationState()
+        data class Error(val message: String) : OperationState()
+    }
 }

--- a/app/src/main/res/layout/fragment_geoevents.xml
+++ b/app/src/main/res/layout/fragment_geoevents.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".ui.geoevents.GeoEventsFragment">
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="GeoEvents"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="8dp" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fab_create_event"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_input_add"
+        android:contentDescription="Create GeoEvent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@id/text_title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp" />
+
+    <TextView
+        android:id="@+id/text_empty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No GeoEvents yet.\nCreate one to start chatting!"
+        android:textSize="16sp"
+        android:textAlignment="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_events"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/text_title"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="16dp"
+        tools:listitem="@layout/item_geoevent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_geoevent.xml
+++ b/app/src/main/res/layout/item_geoevent.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardElevation="2dp"
+    app:cardCornerRadius="8dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="12dp">
+
+        <TextView
+            android:id="@+id/text_event_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="GeoEvent ID"
+            android:textStyle="bold"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/text_user_id"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Created by: "
+            android:textSize="12sp"
+            android:layout_marginTop="4dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginTop="8dp">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_view_chat"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="View Chat"
+                android:textColor="?attr/colorPrimary" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/button_delete"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="Delete"
+                android:textColor="@android:color/holo_red_dark" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
This commit implements the GeoEvents tab with full functionality:
- Updated GeoEventsViewModel with event operations
- Implemented loadGeoEvents() to fetch all user's events
- Implemented loadAvailableStamps() for event creation
- Implemented createGeoEvent() linking events to geostamps
- Implemented deleteGeoEvent() with API integration
- Created new fragment_geoevents.xml layout with FAB
- Created GeoEventsAdapter with view chat and delete actions
- Created item_geoevent.xml for event cards
- Updated GeoEventsFragment with full functionality
- Added create event dialog with geostamp selection
- Added delete confirmation dialog
- Empty state when no events exist
- Navigation to Messages tab (prepared for Phase 6)

Features:
- View all user's geoevents
- Create new geoevent linked to a geostamp
- Select from available unlinked geostamps
- Delete geoevents with confirmation
- View chat button (navigates to Messages tab)
- Auto-refresh after create/delete
- Material Design with FloatingActionButton

User Flow:
1. View all geoevents in GeoEvents tab
2. Click FAB to create new event
3. Select from available geostamps
4. Event created and linked to stamp
5. Click "View Chat" to go to Messages
6. Click "Delete" to remove event

Generated with [Claude Code](https://claude.com/claude-code)