### PR TITLE
Phase 6 (FINAL): Messages/Chat Fragment with event-based messaging

### DIFF
--- a/app/src/main/java/com/geoevent/ui/messages/MessagesAdapter.kt
+++ b/app/src/main/java/com/geoevent/ui/messages/MessagesAdapter.kt
@@ -1,0 +1,72 @@
+package com.geoevent.ui.messages
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.geoevent.data.model.ChatMessage
+import com.geoevent.databinding.ItemMessageBinding
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class MessagesAdapter(
+    private val currentUserId: String
+) : ListAdapter<ChatMessage, MessagesAdapter.MessageViewHolder>(DiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
+        val binding = ItemMessageBinding.inflate(
+            LayoutInflater.from(parent.context),
+            parent,
+            false
+        )
+        return MessageViewHolder(binding, currentUserId)
+    }
+
+    override fun onBindViewHolder(holder: MessageViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class MessageViewHolder(
+        private val binding: ItemMessageBinding,
+        private val currentUserId: String
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(message: ChatMessage) {
+            binding.textContent.text = message.content
+
+            val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+            val time = Date(message.timestamp)
+            binding.textTimestamp.text = timeFormat.format(time)
+
+            // Align message based on sender
+            val layoutParams = binding.cardMessage.layoutParams as ConstraintLayout.LayoutParams
+            if (message.userId == currentUserId) {
+                // My message - align right
+                layoutParams.endToEnd = ConstraintLayout.LayoutParams.PARENT_ID
+                layoutParams.startToStart = ConstraintLayout.LayoutParams.UNSET
+                layoutParams.marginStart = 48
+                layoutParams.marginEnd = 8
+            } else {
+                // Other's message - align left
+                layoutParams.startToStart = ConstraintLayout.LayoutParams.PARENT_ID
+                layoutParams.endToEnd = ConstraintLayout.LayoutParams.UNSET
+                layoutParams.marginStart = 8
+                layoutParams.marginEnd = 48
+            }
+            binding.cardMessage.layoutParams = layoutParams
+        }
+    }
+
+    private class DiffCallback : DiffUtil.ItemCallback<ChatMessage>() {
+        override fun areItemsTheSame(oldItem: ChatMessage, newItem: ChatMessage): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: ChatMessage, newItem: ChatMessage): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/geoevent/ui/messages/MessagesFragment.kt
+++ b/app/src/main/java/com/geoevent/ui/messages/MessagesFragment.kt
@@ -1,42 +1,163 @@
 package com.geoevent.ui.messages
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
-import com.geoevent.databinding.FragmentHomeBinding
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.geoevent.data.auth.SessionManager
+import com.geoevent.databinding.FragmentMessagesBinding
 
 class MessagesFragment : Fragment() {
 
-    private var _binding: FragmentHomeBinding? = null
-
-    // This property is only valid between onCreateView and
-    // onDestroyView.
+    private var _binding: FragmentMessagesBinding? = null
     private val binding get() = _binding!!
+
+    private lateinit var viewModel: MessagesViewModel
+    private lateinit var adapter: MessagesAdapter
+    private lateinit var sessionManager: SessionManager
+
+    private val handler = Handler(Looper.getMainLooper())
+    private val refreshRunnable = object : Runnable {
+        override fun run() {
+            viewModel.refreshMessages()
+            handler.postDelayed(this, 5000) // Refresh every 5 seconds
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        val homeViewModel =
-            ViewModelProvider(this).get(MessagesViewModel::class.java)
+        _binding = FragmentMessagesBinding.inflate(inflater, container, false)
+        viewModel = ViewModelProvider(this)[MessagesViewModel::class.java]
+        sessionManager = SessionManager(requireContext())
 
-        _binding = FragmentHomeBinding.inflate(inflater, container, false)
-        val root: View = binding.root
+        setupRecyclerView()
+        setupObservers()
+        setupClickListeners()
 
-        val textView: TextView = binding.textHome
-        homeViewModel.text.observe(viewLifecycleOwner) {
-            textView.text = it
+        return binding.root
+    }
+
+    private fun setupRecyclerView() {
+        val currentUserId = sessionManager.getUserId() ?: ""
+        adapter = MessagesAdapter(currentUserId)
+
+        binding.recyclerMessages.layoutManager = LinearLayoutManager(requireContext()).apply {
+            stackFromEnd = true // Start from bottom
         }
-        return root
+        binding.recyclerMessages.adapter = adapter
+    }
+
+    private fun setupObservers() {
+        // Observe available events for spinner
+        viewModel.availableEvents.observe(viewLifecycleOwner) { events ->
+            if (events.isEmpty()) {
+                binding.textEmpty.visibility = View.VISIBLE
+                binding.textEmpty.text = "No GeoEvents available.\nCreate one in the GeoEvents tab!"
+                return@observe
+            }
+
+            val eventNames = events.map { "Event: ${it.id.take(8)}..." }
+            val spinnerAdapter = ArrayAdapter(
+                requireContext(),
+                android.R.layout.simple_spinner_item,
+                eventNames
+            )
+            spinnerAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            binding.spinnerEvents.adapter = spinnerAdapter
+
+            binding.spinnerEvents.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                    viewModel.selectEvent(events[position])
+                }
+
+                override fun onNothingSelected(parent: AdapterView<*>?) {}
+            }
+        }
+
+        // Observe selected event
+        viewModel.selectedEvent.observe(viewLifecycleOwner) { event ->
+            if (event != null) {
+                binding.textEmpty.visibility = View.GONE
+                startAutoRefresh()
+            } else {
+                binding.textEmpty.visibility = View.VISIBLE
+                stopAutoRefresh()
+            }
+        }
+
+        // Observe messages
+        viewModel.messages.observe(viewLifecycleOwner) { messages ->
+            adapter.submitList(messages) {
+                // Scroll to bottom after list update
+                if (messages.isNotEmpty()) {
+                    binding.recyclerMessages.scrollToPosition(messages.size - 1)
+                }
+            }
+        }
+
+        // Observe operation state
+        viewModel.operationState.observe(viewLifecycleOwner) { state ->
+            when (state) {
+                is MessagesViewModel.OperationState.Loading -> {
+                    binding.buttonSend.isEnabled = false
+                }
+                is MessagesViewModel.OperationState.Success -> {
+                    binding.buttonSend.isEnabled = true
+                    binding.editMessage.text.clear()
+                }
+                is MessagesViewModel.OperationState.Error -> {
+                    binding.buttonSend.isEnabled = true
+                    Toast.makeText(requireContext(), state.message, Toast.LENGTH_SHORT).show()
+                }
+                else -> {
+                    binding.buttonSend.isEnabled = true
+                }
+            }
+        }
+    }
+
+    private fun setupClickListeners() {
+        binding.buttonSend.setOnClickListener {
+            val content = binding.editMessage.text.toString().trim()
+            if (content.isNotEmpty()) {
+                viewModel.sendMessage(content)
+            }
+        }
+    }
+
+    private fun startAutoRefresh() {
+        stopAutoRefresh()
+        handler.postDelayed(refreshRunnable, 5000)
+    }
+
+    private fun stopAutoRefresh() {
+        handler.removeCallbacks(refreshRunnable)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        viewModel.loadAvailableEvents()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        stopAutoRefresh()
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
+        stopAutoRefresh()
         _binding = null
     }
 }

--- a/app/src/main/java/com/geoevent/ui/messages/MessagesViewModel.kt
+++ b/app/src/main/java/com/geoevent/ui/messages/MessagesViewModel.kt
@@ -1,13 +1,129 @@
 package com.geoevent.ui.messages
 
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.geoevent.data.api.RetrofitClient
+import com.geoevent.data.auth.SessionManager
+import com.geoevent.data.model.ChatMessage
+import com.geoevent.data.model.GeoEvent
+import com.geoevent.data.repository.GeoEventRepository
+import com.geoevent.data.repository.MessageRepository
+import kotlinx.coroutines.launch
+import java.util.UUID
 
-class MessagesViewModel : ViewModel() {
+class MessagesViewModel(application: Application) : AndroidViewModel(application) {
 
-    private val _text = MutableLiveData<String>().apply {
-        value = "[MESSAGES]"
+    private val sessionManager = SessionManager(application)
+    private val messageRepository = MessageRepository(
+        RetrofitClient.getMessageService(sessionManager)
+    )
+    private val geoEventRepository = GeoEventRepository(
+        RetrofitClient.getGeoEventService(sessionManager)
+    )
+
+    private val _messages = MutableLiveData<List<ChatMessage>>()
+    val messages: LiveData<List<ChatMessage>> = _messages
+
+    private val _availableEvents = MutableLiveData<List<GeoEvent>>()
+    val availableEvents: LiveData<List<GeoEvent>> = _availableEvents
+
+    private val _selectedEvent = MutableLiveData<GeoEvent?>()
+    val selectedEvent: LiveData<GeoEvent?> = _selectedEvent
+
+    private val _operationState = MutableLiveData<OperationState>()
+    val operationState: LiveData<OperationState> = _operationState
+
+    init {
+        loadAvailableEvents()
     }
-    val text: LiveData<String> = _text
+
+    fun loadAvailableEvents() {
+        viewModelScope.launch {
+            try {
+                val response = geoEventRepository.getGeoEvents()
+                if (response.isSuccessful && response.body() != null) {
+                    _availableEvents.value = response.body()!!
+                }
+            } catch (e: Exception) {
+                // Silently fail
+            }
+        }
+    }
+
+    fun selectEvent(event: GeoEvent) {
+        _selectedEvent.value = event
+        loadMessages(event.id)
+    }
+
+    fun loadMessages(eventId: String) {
+        viewModelScope.launch {
+            try {
+                val response = messageRepository.getMessages(eventId)
+
+                if (response.isSuccessful && response.body() != null) {
+                    _messages.value = response.body()!!.sortedBy { it.timestamp }
+                } else {
+                    _messages.value = emptyList()
+                }
+            } catch (e: Exception) {
+                _messages.value = emptyList()
+            }
+        }
+    }
+
+    fun sendMessage(content: String) {
+        val event = _selectedEvent.value
+        if (event == null) {
+            _operationState.value = OperationState.Error("No event selected")
+            return
+        }
+
+        val userId = sessionManager.getUserId()
+        if (userId == null) {
+            _operationState.value = OperationState.Error("User not logged in")
+            return
+        }
+
+        viewModelScope.launch {
+            try {
+                _operationState.value = OperationState.Loading
+
+                val message = ChatMessage(
+                    id = UUID.randomUUID().toString(),
+                    eventId = event.id,
+                    content = content,
+                    userId = userId,
+                    timestamp = System.currentTimeMillis()
+                )
+
+                val response = messageRepository.createMessage(message)
+
+                if (response.isSuccessful) {
+                    _operationState.value = OperationState.Success("Message sent")
+                    loadMessages(event.id) // Reload messages
+                } else {
+                    _operationState.value = OperationState.Error("Failed to send: ${response.code()}")
+                }
+            } catch (e: Exception) {
+                _operationState.value = OperationState.Error("Error: ${e.message}")
+            }
+        }
+    }
+
+    fun refreshMessages() {
+        val event = _selectedEvent.value
+        if (event != null) {
+            loadMessages(event.id)
+        }
+    }
+
+    sealed class OperationState {
+        object Idle : OperationState()
+        object Loading : OperationState()
+        data class Success(val message: String) : OperationState()
+        data class Error(val message: String) : OperationState()
+    }
 }

--- a/app/src/main/res/layout/fragment_messages.xml
+++ b/app/src/main/res/layout/fragment_messages.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.messages.MessagesFragment">
+
+    <LinearLayout
+        android:id="@+id/layout_event_selector"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="12dp"
+        android:background="?attr/colorPrimary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Event:"
+            android:textColor="@android:color/white"
+            android:textSize="14sp"
+            android:layout_gravity="center_vertical"
+            android:layout_marginEnd="8dp" />
+
+        <Spinner
+            android:id="@+id/spinner_events"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@android:drawable/btn_dropdown"
+            android:spinnerMode="dropdown" />
+
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/text_empty"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Select an event to start chatting"
+        android:textSize="16sp"
+        android:textAlignment="center"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recycler_messages"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_event_selector"
+        app:layout_constraintBottom_toTopOf="@id/layout_input"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:padding="8dp"
+        tools:listitem="@layout/item_message" />
+
+    <LinearLayout
+        android:id="@+id/layout_input"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="8dp"
+        android:background="?android:attr/colorBackground"
+        android:elevation="4dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <EditText
+            android:id="@+id/edit_message"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:hint="Type a message..."
+            android:inputType="textMultiLine"
+            android:maxLines="4"
+            android:padding="12dp"
+            android:background="@android:drawable/edit_text" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_send"
+            style="@style/Widget.MaterialComponents.Button.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send"
+            android:layout_marginStart="8dp" />
+
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_message.xml
+++ b/app/src/main/res/layout/item_message.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="8dp">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="48dp"
+        android:layout_marginEnd="8dp"
+        app:cardElevation="2dp"
+        app:cardCornerRadius="12dp"
+        app:cardBackgroundColor="?attr/colorPrimary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="12dp"
+            android:minWidth="120dp"
+            android:maxWidth="280dp">
+
+            <TextView
+                android:id="@+id/text_content"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Message content"
+                android:textColor="@android:color/white"
+                android:textSize="14sp" />
+
+            <TextView
+                android:id="@+id/text_timestamp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="12:34 PM"
+                android:textSize="10sp"
+                android:textColor="@android:color/white"
+                android:alpha="0.7"
+                android:layout_marginTop="4dp"
+                android:gravity="end"
+                android:layout_gravity="end" />
+
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This commit implements the final phase - complete chat functionality:
- Updated MessagesViewModel with chat operations
- Implemented loadAvailableEvents() for event selection
- Implemented selectEvent() to switch chat context
- Implemented loadMessages() to fetch chat messages
- Implemented sendMessage() with auto-refresh
- Implemented refreshMessages() for polling
- Created new fragment_messages.xml with chat UI
- Added event selector (Spinner) at top
- Added message input field and send button
- Created MessagesAdapter with message alignment
- Created item_message.xml for chat bubbles
- Updated MessagesFragment with full chat functionality
- Event selection via Spinner
- Real-time message polling (every 5 seconds)
- Auto-scroll to latest message
- Message alignment (own vs others)
- Empty state handling

Features:
- Select GeoEvent to chat in via Spinner
- View all messages for selected event
- Send messages with real-time delivery
- Auto-refresh messages every 5 seconds
- Chat bubble UI with timestamps
- Messages aligned by sender (right for user, left for others)
- Auto-scroll to bottom on new messages
- Proper lifecycle management (pause/resume refresh)
- Empty state when no events available

User Flow:
1. Open Messages tab
2. Select event from Spinner
3. View chat history for that event
4. Type message and click Send
5. Message appears in chat
6. Auto-refreshes every 5 seconds to show new messages

Complete Application Flow:
1. Register/Login → Dashboard
2. Create GeoStamp at location → Dashboard
3. Create GeoEvent linked to stamp → GeoEvents tab
4. Chat with others in event → Messages tab
5. View/manage stamps → GeoStamps tab
6. View/manage events → GeoEvents tab

Generated with [Claude Code](https://claude.com/claude-code)