### PR TITLE
Validate user registration input format

### DIFF
--- a/app/src/main/java/com/geoevent/data/api/AuthService.kt
+++ b/app/src/main/java/com/geoevent/data/api/AuthService.kt
@@ -2,7 +2,7 @@ package com.geoevent.data.api
 
 import com.geoevent.data.model.AuthRequest
 import com.geoevent.data.model.AuthResponse
-import com.geoevent.data.model.User
+import com.geoevent.data.model.RegisterRequest
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
@@ -12,5 +12,5 @@ interface AuthService {
     suspend fun login(@Body authRequest: AuthRequest): Response<AuthResponse>
 
     @POST("/users")
-    suspend fun register(@Body user: User): Response<Unit>
+    suspend fun register(@Body registerRequest: RegisterRequest): Response<Unit>
 }

--- a/app/src/main/java/com/geoevent/data/model/RegisterRequest.kt
+++ b/app/src/main/java/com/geoevent/data/model/RegisterRequest.kt
@@ -1,0 +1,7 @@
+package com.geoevent.data.model
+
+data class RegisterRequest(
+    val name: String,
+    val phoneNumber: String,
+    val password: String
+)

--- a/app/src/main/java/com/geoevent/data/repository/AuthRepository.kt
+++ b/app/src/main/java/com/geoevent/data/repository/AuthRepository.kt
@@ -3,7 +3,7 @@ package com.geoevent.data.repository
 import com.geoevent.data.api.AuthService
 import com.geoevent.data.model.AuthRequest
 import com.geoevent.data.model.AuthResponse
-import com.geoevent.data.model.User
+import com.geoevent.data.model.RegisterRequest
 import retrofit2.Response
 
 class AuthRepository(private val authService: AuthService) {
@@ -12,7 +12,7 @@ class AuthRepository(private val authService: AuthService) {
         return authService.login(AuthRequest(phoneNumber, password))
     }
 
-    suspend fun register(user: User): Response<Unit> {
-        return authService.register(user)
+    suspend fun register(name: String, phoneNumber: String, password: String): Response<Unit> {
+        return authService.register(RegisterRequest(name, phoneNumber, password))
     }
 }

--- a/app/src/main/java/com/geoevent/ui/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/geoevent/ui/auth/AuthViewModel.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
 import com.geoevent.data.api.RetrofitClient
 import com.geoevent.data.auth.SessionManager
-import com.geoevent.data.model.User
 import com.geoevent.data.repository.AuthRepository
 import kotlinx.coroutines.launch
+import java.util.UUID
 
 class AuthViewModel(application: Application) : AndroidViewModel(application) {
 
@@ -49,9 +49,8 @@ class AuthViewModel(application: Application) : AndroidViewModel(application) {
             try {
                 _registerState.value = AuthState.Loading
 
-                // Create user
-                val user = User(id = userId, phoneNumber = phoneNumber, name = name)
-                val registerResponse = authRepository.register(user)
+                // Register user with new structure (name, phoneNumber, password)
+                val registerResponse = authRepository.register(name, phoneNumber, password)
 
                 if (registerResponse.isSuccessful) {
                     // Auto-login after registration


### PR DESCRIPTION
- Created RegisterRequest model with name, phoneNumber, and password fields
- Updated AuthService to use RegisterRequest instead of User model
- Modified AuthRepository.register() to accept individual parameters
- Updated AuthViewModel to send registration data in new format
- Maintained auto-login flow after successful registration

The registration endpoint now receives:
{
  "name": "John Doe", "phoneNumber": "+1234567890", "password": "securePassword123" }